### PR TITLE
Update existing txt records

### DIFF
--- a/docs/resources/livedns_record.md
+++ b/docs/resources/livedns_record.md
@@ -25,8 +25,9 @@ description: |-
 
 ### Optional
 
-- **id** (String) The ID of this resource.
+- **id** (String) The ID of this resource
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- **mutable** (Boolean) Allow manipulation of TXT records that already exists / lives outside of Terraform
 
 ### Read-Only
 


### PR DESCRIPTION
The purpose of this PR is to add a **mutable** flag on **livedns_records** to be able to manipulate records that are susceptible of being already existant / modified aside Terraform.
With this pull request, gandi provider will only touch records managed by Terraform by doing **PUT** crud operation from gandi api in order to **update/edit** the list of records.
[This is the related issue](https://github.com/go-gandi/terraform-provider-gandi/issues/106)